### PR TITLE
include artifact classifier in reported name

### DIFF
--- a/repack/src/main/java/org/basepom/mojo/repack/Reporter.java
+++ b/repack/src/main/java/org/basepom/mojo/repack/Reporter.java
@@ -101,7 +101,15 @@ final class Reporter {
 
     private static SortedMap<String, Artifact> computeNames(Set<Artifact> artifacts) {
         ImmutableSortedMap.Builder<String, Artifact> builder = ImmutableSortedMap.naturalOrder();
-        artifacts.forEach(a -> builder.put(a.getGroupId() + ':' + a.getArtifactId(), a));
+        artifacts.forEach(a -> builder.put(computeArtifactName(a), a));
         return builder.build();
+    }
+
+    private static String computeArtifactName(Artifact artifact) {
+        if (artifact.hasClassifier()) {
+            return artifact.getGroupId() + ':' + artifact.getArtifactId() + ':' + artifact.getClassifier();
+        } else {
+            return artifact.getGroupId() + ':' + artifact.getArtifactId();
+        }
     }
 }


### PR DESCRIPTION
@hgschmie 

In the process of testing repack on my build, I encountered the following error:

```
Caused by: java.lang.IllegalArgumentException: Multiple entries with same key: io.netty:netty-transport-native-epoll=io.netty:netty-transport-native-epoll:jar:4.1.100.Final:compile and io.netty:netty-transport-native-epoll=io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.100.Final:compile
    at com.google.common.collect.ImmutableMap.conflictException (ImmutableMap.java:378)
    at com.google.common.collect.ImmutableMap.checkNoConflict (ImmutableMap.java:372)
    at com.google.common.collect.ImmutableSortedMap.fromEntries (ImmutableSortedMap.java:559)
    at com.google.common.collect.ImmutableSortedMap.access$100 (ImmutableSortedMap.java:67)
    at com.google.common.collect.ImmutableSortedMap$Builder.buildOrThrow (ImmutableSortedMap.java:738)
    at com.google.common.collect.ImmutableSortedMap$Builder.build (ImmutableSortedMap.java:717)
    at org.basepom.mojo.repack.Reporter.computeNames (Reporter.java:105)
    at org.basepom.mojo.repack.Reporter.logReport (Reporter.java:85)
    at org.basepom.mojo.repack.Reporter.report (Reporter.java:66)
    at org.basepom.mojo.repack.RepackMojo.execute (RepackMojo.java:302)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
```
I got around it for now by disabling the reporting functionally of the plugin, but I believe this PR should fix it by properly using the classifier, when present, to deduplicate artifacts.
    